### PR TITLE
fix: guard zoxide initialization for non-interactive shells

### DIFF
--- a/runcom/.oh-my-zsh/custom/aliases.zsh
+++ b/runcom/.oh-my-zsh/custom/aliases.zsh
@@ -3,11 +3,15 @@
 alias reload="source ~/.zshrc"
 alias _="sudo"
 alias rr="rm -rf"
-alias dl="z ~/Downloads"
-alias dt="z ~/Desktop"
-alias p="z ~/Projects"
-alias dot="z ~/.dotfiles && cursor ."
-alias cd="z"
+
+# Zoxide-dependent aliases (guarded for non-interactive shells)
+if command -v zoxide >/dev/null 2>&1; then
+  alias dl="z ~/Downloads"
+  alias dt="z ~/Desktop"
+  alias p="z ~/Projects"
+  alias dot="z ~/.dotfiles && cursor ."
+  alias cd="z"
+fi
 
 # Development
 
@@ -104,11 +108,14 @@ alias paths='echo -e ${PATH//:/\\n}'
 alias l="lsd -lAhF --group-dirs first"
 alias ll="lsd -l --tree"
 
-alias ..="z .."
-alias ...="z ../.."
-alias ....="z ../../.."
-alias -- -="z -"                  # Go to previous dir with -
-alias cd.='z $(readlink -f .)'    # Go to real dir (i.e. if current dir is linked)
+# Zoxide-dependent navigation aliases (guarded for non-interactive shells)
+if command -v zoxide >/dev/null 2>&1; then
+  alias ..="z .."
+  alias ...="z ../.."
+  alias ....="z ../../.."
+  alias -- -="z -"                  # Go to previous dir with -
+  alias cd.='z $(readlink -f .)'    # Go to real dir (i.e. if current dir is linked)
+fi
 
 # npm
 

--- a/runcom/.zshrc
+++ b/runcom/.zshrc
@@ -160,8 +160,10 @@ eval "$(atuin init zsh)"
 # fzf key bindings for completion
 eval "$(fzf --zsh)"
 
-# Zoxide (better cd)
-eval "$(zoxide init zsh)"
+# Zoxide (better cd) - only initialize in interactive shells
+if [[ -o interactive ]]; then
+  eval "$(zoxide init zsh)"
+fi
 
 # Added by LM Studio CLI (lms)
 export PATH="$PATH:$HOME/.lmstudio/bin"


### PR DESCRIPTION
## Summary
Fix intermittent `__zoxide_z` errors in non-interactive environments (Claude Code, CI) by guarding zoxide initialization and z-dependent aliases.

## Changes
- Guard zoxide init in `.zshrc` to only run in interactive shells
- Guard all z-dependent aliases with availability check
- Preserves full functionality in interactive terminals

## Test Plan
- Normal terminal usage with zoxide shortcuts works unchanged
- Running commands like `go build` in Claude Code/CI no longer throws `__zoxide_z` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)