### PR TITLE
feat: add goclean alias for cleanup

### DIFF
--- a/runcom/.oh-my-zsh/custom/aliases.zsh
+++ b/runcom/.oh-my-zsh/custom/aliases.zsh
@@ -36,6 +36,10 @@ alias ddi='docker rmi $(docker images -q)' ## Deletes all images
 alias ddia='docker rmi $(docker images -q --filter "dangling=true") -f ' ## Deletes all untagged images
 alias dclean="dp && ddc && ddi && ddia" ## Cleans up docker
 
+# cleanup
+
+alias goclean="nix-collect-garbage -d && devenv gc && go clean -cache -modcache"
+
 # yarn
 
 alias y="yarn"


### PR DESCRIPTION
Adds a new `goclean` alias that combines cleanup commands for Nix, devenv, and Go.

This alias runs `nix-collect-garbage -d`, `devenv gc`, and `go clean -cache -modcache` in sequence, making it convenient to clean up garbage and caches across these tools.

🤖 Generated with Claude Code