### PR TITLE
refactor: modularize zshrc into separate concern files

### DIFF
--- a/runcom/.oh-my-zsh/custom/asdf.zsh
+++ b/runcom/.oh-my-zsh/custom/asdf.zsh
@@ -1,0 +1,19 @@
+# ASDF Version Manager
+
+if [ -f "$HOME/.asdf/asdf.sh" ]; then
+  . $HOME/.asdf/asdf.sh
+  . $HOME/.asdf/completions/asdf.bash
+  export PATH="$HOME/.asdf/shims:$PATH"
+
+  # Function to automatically install tools based on .tool-versions
+  asdf_auto_install() {
+    if [ -f ".tool-versions" ]; then
+      asdf install
+    fi
+  }
+
+  # Hook the function to the shell prompt command
+  autoload -U add-zsh-hook
+  add-zsh-hook chpwd asdf_auto_install
+  asdf_auto_install
+fi

--- a/runcom/.oh-my-zsh/custom/options.zsh
+++ b/runcom/.oh-my-zsh/custom/options.zsh
@@ -1,0 +1,24 @@
+# Shell Options and Completion Settings
+
+# History
+HISTFILE=$HOME/.zsh_history
+HISTSIZE=100000
+SAVEHIST=$HISTSIZE
+
+# Options
+setopt auto_cd                  # cd by typing directory name if it's not a command
+setopt auto_list                # automatically list choices on ambiguous completion
+setopt auto_menu                # automatically use menu completion
+setopt always_to_end            # move cursor to end if word had one match
+setopt hist_ignore_all_dups     # remove older duplicate entries from history
+setopt hist_reduce_blanks       # remove superfluous blanks from history items
+setopt inc_append_history       # save history entries as soon as they are entered
+setopt share_history            # share history between different instances
+setopt correct_all              # autocorrect commands
+setopt interactive_comments     # allow comments in interactive shells
+
+# Completion styling
+zstyle ':completion:*' menu select                                    # select completions with arrow keys
+zstyle ':completion:*' group-name ''                                  # group results by category
+zstyle ':completion:::::' completer _expand _complete _ignored _approximate  # enable approximate matches
+zstyle ':completion:*:warnings' format ' %F{red}-- no matches found --%f'    # skip missing completion functions gracefully

--- a/runcom/.oh-my-zsh/custom/path.zsh
+++ b/runcom/.oh-my-zsh/custom/path.zsh
@@ -1,0 +1,17 @@
+# PATH Configuration
+# Note: Homebrew PATH is set in .zprofile
+# Note: DOTFILES_DIR/bin PATH is set in .zshenv
+# Note: Rust/Cargo PATH is set in .zshenv via cargo env
+
+# Global npm packages
+export PATH="/usr/local/share/npm/bin:$PATH"
+
+# Serverless
+export PATH="$HOME/.serverless/bin:$PATH"
+
+# Bun
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+# LM Studio CLI
+export PATH="$PATH:$HOME/.lmstudio/bin"

--- a/runcom/.oh-my-zsh/custom/tools.zsh
+++ b/runcom/.oh-my-zsh/custom/tools.zsh
@@ -1,0 +1,39 @@
+# Tool Initializations
+
+# bat theme
+export BAT_THEME=Dracula
+
+# thefuck - command correction
+eval $(thefuck --alias)
+
+# Starship prompt - https://starship.rs/
+eval "$(starship init zsh)"
+
+# Direnv - directory-specific environment variables
+eval "$(direnv hook zsh)"
+
+# Atuin - shell history sync
+. "$HOME/.atuin/bin/env"
+eval "$(atuin init zsh)"
+
+# fzf - fuzzy finder key bindings
+eval "$(fzf --zsh)"
+
+# Zoxide (better cd) - only initialize in interactive shells
+if [[ -o interactive ]]; then
+  eval "$(zoxide init zsh)"
+fi
+
+# Bun completions
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
+
+# Safe-chain
+source ~/.safe-chain/scripts/init-posix.sh
+
+# Warp terminal
+if command -v wt >/dev/null 2>&1; then
+  eval "$(command wt config shell init zsh)"
+fi
+
+# Anthropic model preference
+export ANTHROPIC_MODEL="claude-opus-4-5-20251101"

--- a/runcom/.zshrc
+++ b/runcom/.zshrc
@@ -19,7 +19,7 @@ zinit light-mode for \
     zdharma-continuum/zinit-annex-patch-dl \
     zdharma-continuum/zinit-annex-rust
 
-## End of Zinit's installer chunk
+### End of Zinit's installer chunk
 
 # Enable autocompletions
 autoload -Uz compinit
@@ -36,40 +36,13 @@ else
 fi
 zmodload -i zsh/complist
 
-# Skip missing completion functions gracefully
-zstyle ':completion:*:warnings' format ' %F{red}-- no matches found --%f'
-
-# Save history so we get auto suggestions
-HISTFILE=$HOME/.zsh_history
-HISTSIZE=100000
-SAVEHIST=$HISTSIZE
-
-# Options
-setopt auto_cd # cd by typing directory name if it's not a command
-setopt auto_list # automatically list choices on ambiguous completion
-setopt auto_menu # automatically use menu completion
-setopt always_to_end # move cursor to end if word had one match
-setopt hist_ignore_all_dups # remove older duplicate entries from history
-setopt hist_reduce_blanks # remove superfluous blanks from history items
-setopt inc_append_history # save history entries as soon as they are entered
-setopt share_history # share history between different instances
-setopt correct_all # autocorrect commands
-setopt interactive_comments # allow comments in interactive shells
-
-# Improve autocompletion style
-zstyle ':completion:*' menu select # select completions with arrow keys
-zstyle ':completion:*' group-name '' # group results by category
-zstyle ':completion:::::' completer _expand _complete _ignored _approximate # enable approximate matches for completion
-
-# Plugins
-# zinit light zdharma-continuum/fast-syntax-highlighting
+# Zinit plugins
 zinit light zsh-users/zsh-autosuggestions
 zinit light zsh-users/zsh-history-substring-search
 zinit light zsh-users/zsh-completions
 zinit light buonomo/yarn-completion
-# Note: zsh-notify disabled - shows "unsupported environment" warning in some terminal configurations
-# [[ -x "$(command -v terminal-notifier)" ]] && zinit light marzocchi/zsh-notify
 
+# Oh My Zsh plugins
 plugins=(
   colored-man-pages
   git
@@ -80,100 +53,8 @@ plugins=(
 bindkey '^[[A' history-substring-search-up
 bindkey '^[[B' history-substring-search-down
 
-# Theme
-# zinit light denysdovhan/spaceship-prompt
-SPACESHIP_PROMPT_ORDER=(
-  user          # Username section
-  dir           # Current directory section
-  host          # Hostname section
-  git           # Git section (git_branch + git_status)
-  hg            # Mercurial section (hg_branch  + hg_status)
-  node          #
-  exec_time     # Execution time
-  line_sep      # Line break
-  jobs          # Background jobs indicator
-  exit_code     # Exit code section
-  char          # Prompt character
-)
-SPACESHIP_PROMPT_ADD_NEWLINE=false
-SPACESHIP_CHAR_SYMBOL="❯"
-SPACESHIP_CHAR_SUFFIX=" "
-
-# Reload after loading plugins
+# Load Oh My Zsh (this also sources custom/*.zsh files)
 source $ZSH/oh-my-zsh.sh
 
 # Fixes permissions with the /usr folder
 ZSH_DISABLE_COMPFIX=true
-
-# Fixes global npm packages installation
-export PATH=/usr/local/share/npm/bin:$PATH
-
-# Eval to fix thefuck
-eval $(thefuck --alias)
-
-# Eval to add starship https://starship.rs/
-eval "$(starship init zsh)"
-
-# Added by serverless binary installer
-export PATH="$HOME/.serverless/bin:$PATH"
-
-# Rust
-export PATH="$HOME/.cargo/bin:$PATH"
-
-# bun completions
-[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
-
-# bun
-export BUN_INSTALL="$HOME/.bun"
-export PATH="$BUN_INSTALL/bin:$PATH"
-
-# ASDF
-if [ -f "$HOME/.asdf/asdf.sh" ]; then
-  . $HOME/.asdf/asdf.sh
-  . $HOME/.asdf/completions/asdf.bash
-  export PATH="$HOME/.asdf/shims:$PATH"
-
-  # Function to automatically install tools based on .tool-versions
-  asdf_auto_install() {
-    if [ -f ".tool-versions" ]; then
-      asdf install
-    fi
-  }
-
-  # Hook the function to the shell prompt command
-  autoload -U add-zsh-hook
-  add-zsh-hook chpwd asdf_auto_install
-  asdf_auto_install
-fi
-
-# bat
-export BAT_THEME=Dracula
-
-. "$HOME/.atuin/bin/env"
-
-# Direnv
-eval "$(direnv hook zsh)"
-
-# Atuin
-eval "$(atuin init zsh)"
-
-# fzf key bindings for completion
-eval "$(fzf --zsh)"
-
-# Zoxide (better cd) - only initialize in interactive shells
-if [[ -o interactive ]]; then
-  eval "$(zoxide init zsh)"
-fi
-
-# Added by LM Studio CLI (lms)
-export PATH="$PATH:$HOME/.lmstudio/bin"
-# End of LM Studio CLI section
-
-# Added by LM Studio CLI (lms)
-export PATH="$PATH:/Users/elliot/.lmstudio/bin"
-# End of LM Studio CLI section
-
-source ~/.safe-chain/scripts/init-posix.sh # Safe-chain Zsh initialization script
-
-if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)"; fi
-export ANTHROPIC_MODEL="claude-opus-4-5-20251101"


### PR DESCRIPTION
Reorganize shell configuration by extracting history/options, PATH exports, tool initializations, and ASDF setup into dedicated files. This reduces .zshrc from 180 to 60 lines while improving maintainability.

Changes:
- Extract options.zsh: History settings, setopt options, completion styling
- Extract path.zsh: Consolidated PATH exports (npm, serverless, bun, lmstudio)
- Extract tools.zsh: Tool initializations (starship, thefuck, direnv, atuin, fzf, zoxide)
- Extract asdf.zsh: ASDF version manager configuration
- Remove dead Spaceship theme config (using Starship instead)
- Remove duplicate LM Studio PATH entry

🤖 Generated with Claude Code