### PR TITLE
fix: improve shell initialization and completion handling

### DIFF
--- a/runcom/.oh-my-zsh/custom/aliases.zsh
+++ b/runcom/.oh-my-zsh/custom/aliases.zsh
@@ -1,6 +1,7 @@
 # Shortcuts
 
-alias reload="source ~/.zshrc"
+# Use exec zsh for clean reload (avoids completion conflicts from re-sourcing)
+alias reload="exec zsh"
 alias _="sudo"
 alias rr="rm -rf"
 

--- a/runcom/.oh-my-zsh/custom/asdf.zsh
+++ b/runcom/.oh-my-zsh/custom/asdf.zsh
@@ -2,8 +2,10 @@
 
 if [ -f "$HOME/.asdf/asdf.sh" ]; then
   . $HOME/.asdf/asdf.sh
-  . $HOME/.asdf/completions/asdf.bash
   export PATH="$HOME/.asdf/shims:$PATH"
+
+  # Append asdf completions to fpath (zsh-native, avoids bash completion issues)
+  fpath=(${ASDF_DIR}/completions $fpath)
 
   # Function to automatically install tools based on .tool-versions
   asdf_auto_install() {

--- a/runcom/.zshrc
+++ b/runcom/.zshrc
@@ -28,19 +28,23 @@ autoload -Uz compinit
 fpath=(/opt/homebrew/share/zsh/site-functions $fpath)
 [ -d /usr/local/share/zsh/site-functions ] && fpath=(/usr/local/share/zsh/site-functions $fpath)
 
-typeset -i updated_at=$(date +'%j' -r ~/.zcompdump 2>/dev/null || stat -f '%Sm' -t '%j' ~/.zcompdump 2>/dev/null)
-if [ $(date +'%j') != $updated_at ]; then
-  compinit -i
-else
-  compinit -C -i
+# Guard against multiple compinit calls during reload
+if [[ -z "$_COMPINIT_DONE" ]]; then
+  typeset -i updated_at=$(date +'%j' -r ~/.zcompdump 2>/dev/null || stat -f '%Sm' -t '%j' ~/.zcompdump 2>/dev/null)
+  if [ $(date +'%j') != $updated_at ]; then
+    compinit -i
+  else
+    compinit -C -i
+  fi
+  zmodload -i zsh/complist
+  _COMPINIT_DONE=1
 fi
-zmodload -i zsh/complist
 
 # Zinit plugins
 zinit light zsh-users/zsh-autosuggestions
 zinit light zsh-users/zsh-history-substring-search
 zinit light zsh-users/zsh-completions
-zinit light buonomo/yarn-completion
+# Note: yarn completion provided by oh-my-zsh yarn plugin below
 
 # Oh My Zsh plugins
 plugins=(
@@ -53,11 +57,11 @@ plugins=(
 bindkey '^[[A' history-substring-search-up
 bindkey '^[[B' history-substring-search-down
 
+# Fixes permissions with the /usr folder - MUST be before oh-my-zsh.sh
+ZSH_DISABLE_COMPFIX=true
+
 # Load Oh My Zsh (sources custom/*.zsh: aliases, asdf, nvm, options, path)
 source $ZSH/oh-my-zsh.sh
-
-# Fixes permissions with the /usr folder
-ZSH_DISABLE_COMPFIX=true
 
 # =============================================================================
 # Tool Initializations - MUST be after oh-my-zsh loads


### PR DESCRIPTION
## Summary

Fixes shell initialization issues that cause completion conflicts and cascading failures during shell reload. Updates reload alias to use exec for clean restarts, moves asdf completions to zsh-native fpath, adds guards against multiple compinit calls, and reorganizes initialization order.

## Changes

- Update `reload` alias to use `exec zsh` instead of `source` to avoid completion conflicts
- Move asdf completions to fpath for native zsh support instead of bash completions  
- Add guard to prevent multiple compinit calls during reload
- Move `ZSH_DISABLE_COMPFIX` before oh-my-zsh.sh load for proper initialization order

🤖 Generated with [Claude Code](https://claude.com/claude-code)