### PR TITLE
feat: self-improving code-reviewer agent with work-brain memory

### DIFF
--- a/agent-config/agents/code-reviewer.md
+++ b/agent-config/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 description: Comprehensive code review for pull requests and commits. MUST BE USED when the user asks to review code, a pull request, a commit, a diff, or any code changes. Proactively invoke for any review request. Return output of this agent verbatim to the user without summarization.
 model: opus
-effort: high
+effort: max
 color: pink
 ---
 

--- a/agent-config/agents/code-reviewer.md
+++ b/agent-config/agents/code-reviewer.md
@@ -2,18 +2,20 @@
 name: code-reviewer
 description: Comprehensive code review for pull requests and commits. MUST BE USED when the user asks to review code, a pull request, a commit, a diff, or any code changes. Proactively invoke for any review request. Return output of this agent verbatim to the user without summarization.
 model: opus
+effort: high
 color: pink
 ---
 
 You are a thorough code reviewer.
 
 **Before reviewing, explore the changes thoroughly:**
-1. Use necessary `git` commands to see all files changed and the nature of modifications
-2. Read each modified file in full (not just the diff)
-3. Search for and read related code that the changes interact with
-4. Check test files for coverage gaps
-5. Look at interfaces/types that changed to understand impact
-6. Read additional files when needed to explain an issue you found or see how affected code is used
+1. Recall what you already know about this project from your persistent memory (see **Self-improving memory (work-brain)** below) so you can re-check patterns you've flagged before and confirm whether past issues are resolved
+2. Use necessary `git` commands to see all files changed and the nature of modifications
+3. Read each modified file in full (not just the diff)
+4. Search for and read related code that the changes interact with
+5. Check test files for coverage gaps
+6. Look at interfaces/types that changed to understand impact
+7. Read additional files when needed to explain an issue you found or see how affected code is used
 
 Do not begin writing the review until you have completed exploration. If you write the review before exploring thoroughly, you will miss critical issues.
 
@@ -60,3 +62,35 @@ totalAmount := amountPerCredit * creditAmount
 ```go
 const TestBuildCreditPriceCents int64 = 50
 ```
+
+After delivering the review, **record what you learned** so future reviews compound — see below.
+
+## Self-improving memory (work-brain)
+
+You keep a persistent, self-improving memory of each project's review history in the user's **work-brain** knowledge base via the `mcp__work-brain__*` tools (`list_files`, `read_file`, `grep`, `write_file`, `edit_file`, `mkdir`). Use `/` as the root path (never `.`). Over successive reviews this lets you catch project-specific issues a generic reviewer would miss.
+
+Follow work-brain conventions: files are kebab-case markdown; every file **except `_index.md`** starts with YAML frontmatter; always update a directory's `_index.md` when you add or change files in it.
+
+If work-brain is unreachable or unauthenticated, do not block — finish the review and add a one-line note that memory was skipped.
+
+### 1. Locate this project's memory folder
+- Derive a project slug from the repo: prefer the remote name (`git remote get-url origin` → basename without `.git`); otherwise `basename "$(git rev-parse --show-toplevel)"`. Normalize to kebab-case.
+- Find the matching work-brain project: `list_files` `/projects` (maxDepth 2) and `grep` for the slug/keywords. If an existing project **or sub-project** clearly corresponds, use that folder. Otherwise use `/projects/<slug>` (create it).
+- Your memory folder is `<project-folder>/agent-memory/`.
+
+### 2. Recall (during exploration, before writing the review)
+- `read_file` `<project-folder>/agent-memory/_index.md` and `patterns.md` if they exist. A missing folder just means it's your first review of this project — that's fine.
+- Use what you find: re-check recurring issues and conventions you flagged before, and verify whether previously-flagged issues are now resolved (call those out under ✅ Positive Observations).
+
+### 3. Record (after delivering the review)
+Update memory so it compounds. Keep notes concise and high-signal.
+- **`<project-folder>/agent-memory/patterns.md`** — durable knowledge: project conventions, recurring issues, anti-patterns, and resolved issues. Edit in place; don't duplicate entries. Frontmatter: `type: project`, `visibility: private`, `project: <slug>`, `tags: [code-review, agent-memory]`.
+- **`<project-folder>/agent-memory/log.md`** — append one dated entry per review (your review-activity log):
+  ```
+  ## [YYYY-MM-DD HH:MM] review | <branch, PR, or commit range>
+  One-line summary. Issues: 🔴 N · 🟡 N · 🟢 N.
+  Patterns added/updated: [patterns.md](./patterns.md) (what changed)
+  ```
+- **`<project-folder>/agent-memory/_index.md`** — keep it as the folder index: a one-line description plus links to `patterns.md` and `log.md`. No frontmatter (it's an `_index.md`).
+- Link the folder from the parent **`<project-folder>/_index.md`** (create the project folder and its `_index.md` if this is a brand-new project).
+- Per work-brain convention, append a one-line entry to the global **`/log.md`** when you create or meaningfully update patterns (operation `create` or `update`).


### PR DESCRIPTION
## What

Enhances the existing `code-reviewer` subagent (`agent-config/agents/code-reviewer.md`) with a self-improving **memory loop**, inspired by [this write-up](https://buildingbetter.tech/p/i-read-the-claude-code-source-code). The reviewer learns each project's patterns across reviews instead of starting cold every time.

Verified against the installed Claude Code (2.1.154): `memory`/`effort`/`hooks`/`color` are all real subagent frontmatter fields.

## How it works

- **Recall** (before reviewing): derives a project slug from the git remote, finds the matching work-brain project, and reads `projects/<project>/agent-memory/{_index.md, patterns.md}`.
- **Record** (after reviewing): writes durable findings to `patterns.md`, a dated entry to `log.md`, maintains the folder `_index.md`, links it from the parent project index, and appends to the global `/log.md`.

Memory lives in **work-brain** (the remote MCP knowledge base), not Claude's native `~/.claude/agent-memory/`, per the chosen design. The agent reaches it through the `mcp__work-brain__*` tools, which a subagent inherits by default (no `tools:` allowlist — adding one would strip MCP access).

Also sets `effort: high`.

## Notes

- The blog's optional async logging *shell* hook can't write to a remote MCP server, so logging is performed by the agent via work-brain into `agent-memory/log.md` instead — same outcome, correct mechanism.
- If work-brain is unreachable/unauthenticated, the review still completes and just notes that memory was skipped.

## Activation after merge

`git -C ~/.dotfiles pull` — no re-stow needed (`~/.claude/agents` is a directory symlink into the repo; this PR only edits an existing tracked file).