### PR TITLE
refactor: rename code-reviewer agent to personal-code-reviewer

### DIFF
--- a/agent-config/agents/personal-code-reviewer.md
+++ b/agent-config/agents/personal-code-reviewer.md
@@ -1,6 +1,6 @@
 ---
-name: code-reviewer
-description: Comprehensive code review for pull requests and commits. MUST BE USED when the user asks to review code, a pull request, a commit, a diff, or any code changes. Proactively invoke for any review request. Return output of this agent verbatim to the user without summarization.
+name: personal-code-reviewer
+description: Personal, self-improving code reviewer that persists findings to work-brain memory. Comprehensive review of pull requests, commits, and diffs. MUST BE USED when the user asks to review code, a pull request, a commit, a diff, or any code changes. In repos that ship their own `code-reviewer` agent, invoke this one explicitly by name (`personal-code-reviewer`). Return output of this agent verbatim to the user without summarization.
 model: opus
 effort: max
 color: pink


### PR DESCRIPTION
## What

Renames the personal `code-reviewer` subagent to **`personal-code-reviewer`** (`agent-config/agents/`). Pure rename + frontmatter (`name`/`description`) — no behavior change to the review logic itself.

## Why

Repos that ship their own project-level `code-reviewer` agent — e.g. the one committed in the lovable repo at `.agents/agents/code-reviewer.md` — **shadow** this user-level agent, because project agents win name collisions. That project copy has a restrictive `tools:` allowlist (no MCP) and no work-brain instructions, so when reviewing inside those workspaces the work-brain–enabled reviewer never ran and nothing was persisted.

Renaming removes the collision: both agents coexist, and the personal, work-brain–enabled reviewer can be invoked explicitly by name.

## After merging

`~/.claude/agents` is symlinked into a **separate checkout** (`~/.dotfiles`), so merging alone doesn't make it live — pull there:

```bash
git -C ~/.dotfiles pull
```

Then invoke it in any workspace by name:

> Review this PR with the **personal-code-reviewer** agent.
