### PR TITLE
feat: cache agent CLI secrets locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,47 @@ an app-managed runtime mirror under its own `$CODEX_HOME`; that generated file
 is deliberately not symlinked because Orca rewrites it atomically when syncing
 settings and managed hooks.
 
-The `codex` and `claude` aliases launch through `op run`, loading secret
-references from `agent-config/secrets/env.1password`. Keep only `op://`
-references there, then point MCP configs at those environment variable names.
-Requires 1Password's Developer setting for CLI integration.
+The `codex` and `claude` aliases load secrets from the local, Git-ignored
+`agent-config/secrets/env.cache`. Create or update it explicitly:
+
+```bash
+agent-secrets refresh
+```
+
+When testing from a worktree before it has become the active dotfiles checkout,
+invoke the utility by path instead:
+
+```bash
+./bin/agent-secrets refresh
+```
+
+It reads the template from that worktree but stores the ignored cache under the
+active `$DOTFILES_DIR`, so the cache remains available after the worktree is
+merged or removed.
+
+The refresh command resolves the references in
+`agent-config/secrets/env.1password` with the 1Password CLI. It is the only
+operation that contacts 1Password, so normal agent launches do not require an
+approval. Run it again whenever a secret rotates.
+
+The cache is plaintext local state. Its directory is restricted to mode `0700`
+and the cache to `0600`; full-disk encryption and the local user account provide
+the remaining at-rest protection. The cache must contain single-line dotenv
+values. It is written atomically, and a failed refresh leaves the previous cache
+intact.
+
+Useful commands:
+
+```bash
+agent-secrets status  # Show cache metadata without values
+agent-secrets clear   # Remove the cached secrets
+```
+
+To add a secret, put a `NAME={{ op://vault/item/field }}` reference in the
+tracked template and configure the relevant MCP server to read `NAME` from its
+environment. A missing, invalid, unresolved, or overly permissive cache prevents
+Codex and Claude from starting and directs you to refresh it. Requires
+1Password's Developer setting for CLI integration.
 
 ## Additional Resources
 

--- a/agent-config/secrets/env.1password
+++ b/agent-config/secrets/env.1password
@@ -4,7 +4,7 @@
 # Example:
 #   bearer_token_env_var = "WORK_BRAIN_BEARER_TOKEN"
 
-WORK_BRAIN_BEARER_TOKEN=op://Personal/brain-dtb/bearer-token
+WORK_BRAIN_BEARER_TOKEN={{ op://Personal/brain-dtb/bearer-token }}
 
 # Force Codex onto its TLS 1.3-capable rustls backend for the Lovable MCP endpoint.
 CODEX_CA_CERTIFICATE=/etc/ssl/cert.pem

--- a/bin/agent-secrets
+++ b/bin/agent-secrets
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SOURCE_DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ACTIVE_DOTFILES_DIR="${DOTFILES_DIR:-$SOURCE_DOTFILES_DIR}"
+SECRETS_DIR="${AGENT_SECRETS_DIR:-$ACTIVE_DOTFILES_DIR/agent-config/secrets}"
+TEMPLATE_FILE="${AGENT_SECRETS_TEMPLATE:-$SOURCE_DOTFILES_DIR/agent-config/secrets/env.1password}"
+CACHE_FILE="${AGENT_SECRETS_CACHE:-$SECRETS_DIR/env.cache}"
+OP_ACCOUNT="${AGENT_SECRETS_OP_ACCOUNT:-my.1password.com}"
+REFRESH_TEMP_FILE=''
+
+usage() {
+  cat <<'EOF'
+Usage: agent-secrets <command> [arguments]
+
+Commands:
+  refresh             Refresh the local cache from 1Password
+  exec <command...>   Run a command with the cached environment
+  status              Show cache metadata and validation status
+  clear               Remove the local cache
+EOF
+}
+
+file_mode() {
+  stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1"
+}
+
+file_owner() {
+  stat -f '%u' "$1" 2>/dev/null || stat -c '%u' "$1"
+}
+
+file_mtime() {
+  stat -f '%m' "$1" 2>/dev/null || stat -c '%Y' "$1"
+}
+
+cleanup_refresh_temp() {
+  if [[ -n "$REFRESH_TEMP_FILE" ]]; then
+    rm -f -- "$REFRESH_TEMP_FILE"
+  fi
+}
+
+validate_cache_contents() {
+  local file="$1"
+  local line
+  local line_number=0
+  local assignment_count=0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+
+    case "$line" in
+      ''|'#'*) continue ;;
+    esac
+
+    if [[ ! "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+      echo "error: invalid cache entry on line $line_number" >&2
+      return 1
+    fi
+
+    if [[ "$line" == *'op://'* || "$line" == *'{{'* || "$line" == *'}}'* ]]; then
+      echo "error: unresolved 1Password reference on line $line_number" >&2
+      return 1
+    fi
+
+    assignment_count=$((assignment_count + 1))
+  done < "$file"
+
+  if [[ "$assignment_count" -eq 0 ]]; then
+    echo "error: cache contains no environment assignments" >&2
+    return 1
+  fi
+}
+
+validate_cache() {
+  if [[ ! -e "$CACHE_FILE" ]]; then
+    echo "error: agent secret cache is missing" >&2
+    echo "run 'agent-secrets refresh' to create it" >&2
+    return 1
+  fi
+
+  if [[ -L "$CACHE_FILE" || ! -f "$CACHE_FILE" ]]; then
+    echo "error: agent secret cache must be a regular file, not a symlink" >&2
+    return 1
+  fi
+
+  local cache_dir
+  cache_dir="$(dirname "$CACHE_FILE")"
+
+  local directory_mode
+  directory_mode="$(file_mode "$cache_dir")"
+  if [[ "$directory_mode" != "700" ]]; then
+    echo "error: agent secret cache directory permissions are $directory_mode; expected 700" >&2
+    echo "run 'chmod 700 $cache_dir' or refresh the cache" >&2
+    return 1
+  fi
+
+  local mode
+  mode="$(file_mode "$CACHE_FILE")"
+  if [[ "$mode" != "600" ]]; then
+    echo "error: agent secret cache permissions are $mode; expected 600" >&2
+    echo "run 'chmod 600 $CACHE_FILE' or refresh the cache" >&2
+    return 1
+  fi
+
+  local owner
+  owner="$(file_owner "$CACHE_FILE")"
+  if [[ "$owner" != "$(id -u)" ]]; then
+    echo "error: agent secret cache is not owned by the current user" >&2
+    return 1
+  fi
+
+  validate_cache_contents "$CACHE_FILE"
+}
+
+refresh_cache() {
+  if [[ ! -f "$TEMPLATE_FILE" ]]; then
+    echo "error: 1Password template not found: $TEMPLATE_FILE" >&2
+    return 1
+  fi
+
+  if ! command -v op >/dev/null 2>&1; then
+    echo "error: 1Password CLI ('op') is not installed" >&2
+    return 1
+  fi
+
+  mkdir -p "$SECRETS_DIR"
+  chmod 700 "$SECRETS_DIR"
+
+  REFRESH_TEMP_FILE="$(mktemp "${CACHE_FILE}.tmp.XXXXXX")"
+  trap cleanup_refresh_temp EXIT HUP INT TERM
+
+  op inject \
+    --account "$OP_ACCOUNT" \
+    --in-file "$TEMPLATE_FILE" \
+    --out-file "$REFRESH_TEMP_FILE" \
+    --file-mode 0600 \
+    --force
+
+  chmod 600 "$REFRESH_TEMP_FILE"
+  validate_cache_contents "$REFRESH_TEMP_FILE"
+  mv -f -- "$REFRESH_TEMP_FILE" "$CACHE_FILE"
+  REFRESH_TEMP_FILE=''
+  trap - EXIT HUP INT TERM
+
+  echo "Agent secret cache refreshed: $CACHE_FILE"
+}
+
+load_cache() {
+  local line
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      ''|'#'*) continue ;;
+    esac
+
+    export "${line?}"
+  done < "$CACHE_FILE"
+}
+
+exec_with_cache() {
+  if [[ "$#" -eq 0 ]]; then
+    echo "error: exec requires a command" >&2
+    usage >&2
+    return 2
+  fi
+
+  validate_cache
+  load_cache
+  exec "$@"
+}
+
+show_status() {
+  if [[ ! -e "$CACHE_FILE" ]]; then
+    echo "Cache: missing ($CACHE_FILE)"
+    return 1
+  fi
+
+  echo "Cache: $CACHE_FILE"
+  echo "Mode: $(file_mode "$CACHE_FILE")"
+  echo "Modified (epoch): $(file_mtime "$CACHE_FILE")"
+
+  if validate_cache; then
+    echo "Status: valid"
+  else
+    echo "Status: invalid"
+    return 1
+  fi
+}
+
+clear_cache() {
+  if [[ -e "$CACHE_FILE" || -L "$CACHE_FILE" ]]; then
+    rm -f -- "$CACHE_FILE"
+    echo "Agent secret cache removed: $CACHE_FILE"
+  else
+    echo "Agent secret cache is already absent: $CACHE_FILE"
+  fi
+}
+
+case "${1:-}" in
+  refresh)
+    shift
+    if [[ "$#" -ne 0 ]]; then
+      usage >&2
+      exit 2
+    fi
+    refresh_cache
+    ;;
+  exec)
+    shift
+    exec_with_cache "$@"
+    ;;
+  status)
+    shift
+    if [[ "$#" -ne 0 ]]; then
+      usage >&2
+      exit 2
+    fi
+    show_status
+    ;;
+  clear)
+    shift
+    if [[ "$#" -ne 0 ]]; then
+      usage >&2
+      exit 2
+    fi
+    clear_cache
+    ;;
+  ''|-h|--help|help)
+    usage
+    ;;
+  *)
+    echo "error: unknown command: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/runcom/.oh-my-zsh/custom/aliases.zsh
+++ b/runcom/.oh-my-zsh/custom/aliases.zsh
@@ -26,8 +26,8 @@ alias k="kubectl"
 alias c="code ."
 
 # Agent CLIs
-alias codex='op run --account my.1password.com --no-masking --env-file "$HOME/.dotfiles/agent-config/secrets/env.1password" -- codex'
-alias claude='op run --account my.1password.com --no-masking --env-file "$HOME/.dotfiles/agent-config/secrets/env.1password" -- claude'
+alias codex='agent-secrets exec codex'
+alias claude='agent-secrets exec claude'
 
 # tmux
 alias t="tmux"

--- a/test/agent-secrets.bats
+++ b/test/agent-secrets.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_ROOT
+  TEST_ROOT="$(mktemp -d)"
+  export AGENT_SECRETS_DIR="$TEST_ROOT/secrets"
+  export AGENT_SECRETS_TEMPLATE="$AGENT_SECRETS_DIR/env.1password"
+  export AGENT_SECRETS_CACHE="$AGENT_SECRETS_DIR/env.cache"
+  export AGENT_SECRETS_OP_ACCOUNT="test.1password.local"
+  AGENT_SECRETS="$BATS_TEST_DIRNAME/../bin/agent-secrets"
+
+  mkdir -p "$AGENT_SECRETS_DIR" "$TEST_ROOT/bin"
+}
+
+teardown() {
+  rm -rf -- "$TEST_ROOT"
+}
+
+install_op_stub() {
+  cat > "$TEST_ROOT/bin/op" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output=''
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --out-file)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ "${OP_STUB_FAIL:-0}" == "1" ]]; then
+  exit 1
+fi
+
+printf '%s\n' \
+  '# resolved cache' \
+  'WORK_BRAIN_BEARER_TOKEN=resolved token=with spaces' \
+  'CODEX_CA_CERTIFICATE=/etc/ssl/cert.pem' > "$output"
+EOF
+  chmod 755 "$TEST_ROOT/bin/op"
+}
+
+make_valid_cache() {
+  printf '%s\n' \
+    '# local cache' \
+    'FIRST_SECRET=value with spaces' \
+    'SECOND_SECRET=value=with=equals' > "$AGENT_SECRETS_CACHE"
+  chmod 700 "$AGENT_SECRETS_DIR"
+  chmod 600 "$AGENT_SECRETS_CACHE"
+}
+
+@test "refresh writes a validated cache with private permissions" {
+  install_op_stub
+  printf '%s\n' 'FIRST_SECRET={{ op://Test/item/value }}' > "$AGENT_SECRETS_TEMPLATE"
+
+  run env PATH="$TEST_ROOT/bin:$PATH" "$AGENT_SECRETS" refresh
+
+  [ "$status" -eq 0 ]
+  [ "$(stat -f '%Lp' "$AGENT_SECRETS_DIR" 2>/dev/null || stat -c '%a' "$AGENT_SECRETS_DIR")" = "700" ]
+  [ "$(stat -f '%Lp' "$AGENT_SECRETS_CACHE" 2>/dev/null || stat -c '%a' "$AGENT_SECRETS_CACHE")" = "600" ]
+  grep -q '^WORK_BRAIN_BEARER_TOKEN=resolved token=with spaces$' "$AGENT_SECRETS_CACHE"
+  run find "$AGENT_SECRETS_DIR" -name 'env.cache.tmp.*' -print
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "a worktree command stores its cache under the active dotfiles directory" {
+  install_op_stub
+  local active_dotfiles="$TEST_ROOT/active-dotfiles"
+  unset AGENT_SECRETS_DIR AGENT_SECRETS_TEMPLATE AGENT_SECRETS_CACHE
+  mkdir -p "$active_dotfiles/agent-config/secrets"
+
+  run env \
+    DOTFILES_DIR="$active_dotfiles" \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    "$AGENT_SECRETS" refresh
+
+  [ "$status" -eq 0 ]
+  [ -f "$active_dotfiles/agent-config/secrets/env.cache" ]
+  [ ! -f "$BATS_TEST_DIRNAME/../agent-config/secrets/env.cache" ]
+}
+
+@test "a failed refresh preserves the previous cache" {
+  install_op_stub
+  make_valid_cache
+  cp "$AGENT_SECRETS_CACHE" "$TEST_ROOT/original-cache"
+  printf '%s\n' 'FIRST_SECRET={{ op://Test/item/value }}' > "$AGENT_SECRETS_TEMPLATE"
+
+  run env PATH="$TEST_ROOT/bin:$PATH" OP_STUB_FAIL=1 "$AGENT_SECRETS" refresh
+
+  [ "$status" -ne 0 ]
+  cmp "$TEST_ROOT/original-cache" "$AGENT_SECRETS_CACHE"
+  run find "$AGENT_SECRETS_DIR" -name 'env.cache.tmp.*' -print
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "exec exports cache values and forwards arguments and exit status" {
+  make_valid_cache
+
+  # shellcheck disable=SC2016
+  run "$AGENT_SECRETS" exec sh -c \
+    'printf "%s|%s|%s" "$FIRST_SECRET" "$SECOND_SECRET" "$1"; exit 7' \
+    test-command 'argument with spaces'
+
+  [ "$status" -eq 7 ]
+  [ "$output" = 'value with spaces|value=with=equals|argument with spaces' ]
+}
+
+@test "exec treats shell syntax in values as data" {
+  local marker="$TEST_ROOT/should-not-exist"
+  # shellcheck disable=SC2016
+  printf '%s\n' 'SAFE=value' "EVIL=\$(touch $marker)" > "$AGENT_SECRETS_CACHE"
+  chmod 700 "$AGENT_SECRETS_DIR"
+  chmod 600 "$AGENT_SECRETS_CACHE"
+
+  run "$AGENT_SECRETS" exec true
+
+  [ "$status" -eq 0 ]
+  [ ! -e "$marker" ]
+}
+
+@test "exec fails closed for a missing cache" {
+  run "$AGENT_SECRETS" exec true
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"agent-secrets refresh"* ]]
+}
+
+@test "exec rejects unresolved references and permissive files" {
+  printf '%s\n' 'FIRST_SECRET={{ op://Test/item/value }}' > "$AGENT_SECRETS_CACHE"
+  chmod 700 "$AGENT_SECRETS_DIR"
+  chmod 600 "$AGENT_SECRETS_CACHE"
+
+  run "$AGENT_SECRETS" exec true
+  [ "$status" -ne 0 ]
+  [[ "$output" == *'unresolved 1Password reference'* ]]
+
+  printf '%s\n' 'FIRST_SECRET=value' > "$AGENT_SECRETS_CACHE"
+  chmod 644 "$AGENT_SECRETS_CACHE"
+
+  run "$AGENT_SECRETS" exec true
+  [ "$status" -ne 0 ]
+  [[ "$output" == *'expected 600'* ]]
+
+  chmod 600 "$AGENT_SECRETS_CACHE"
+  chmod 755 "$AGENT_SECRETS_DIR"
+
+  run "$AGENT_SECRETS" exec true
+  [ "$status" -ne 0 ]
+  [[ "$output" == *'expected 700'* ]]
+}
+
+@test "status omits values and clear removes only the cache" {
+  make_valid_cache
+  printf '%s\n' 'template remains' > "$AGENT_SECRETS_TEMPLATE"
+
+  run "$AGENT_SECRETS" status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'Status: valid'* ]]
+  [[ "$output" != *'value with spaces'* ]]
+
+  run "$AGENT_SECRETS" clear
+  [ "$status" -eq 0 ]
+  [ ! -e "$AGENT_SECRETS_CACHE" ]
+  [ -e "$AGENT_SECRETS_TEMPLATE" ]
+}


### PR DESCRIPTION
## Summary

- cache 1Password-backed agent secrets in a private, Git-ignored dotenv file
- make Codex and Claude launches non-interactive after an explicit refresh
- validate permissions and cache contents, with atomic refresh and status/clear commands
- keep worktree refreshes pointed at the active dotfiles cache

## Testing

- `shellcheck bin/agent-secrets test/agent-secrets.bats`
- `DOTFILES_DIR="$PWD" bin/dotfiles test`
- Bash and Zsh syntax checks
- Git ignore and tracked-template checks