### PR TITLE
fix: support GNU stat in macOS Nix shells

### DIFF
--- a/bin/agent-secrets
+++ b/bin/agent-secrets
@@ -23,15 +23,15 @@ EOF
 }
 
 file_mode() {
-  stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1"
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
 }
 
 file_owner() {
-  stat -f '%u' "$1" 2>/dev/null || stat -c '%u' "$1"
+  stat -c '%u' "$1" 2>/dev/null || stat -f '%u' "$1"
 }
 
 file_mtime() {
-  stat -f '%m' "$1" 2>/dev/null || stat -c '%Y' "$1"
+  stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1"
 }
 
 cleanup_refresh_temp() {

--- a/test/agent-secrets.bats
+++ b/test/agent-secrets.bats
@@ -46,6 +46,37 @@ EOF
   chmod 755 "$TEST_ROOT/bin/op"
 }
 
+install_gnu_stat_stub() {
+  local real_stat
+  real_stat="$(command -v stat)"
+
+  cat > "$TEST_ROOT/bin/stat" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" == "-f" ]]; then
+  printf '  File: "%s"\nBlock size: 4096\n' "$3"
+  exit 1
+fi
+
+if [[ "$1" == "-c" ]]; then
+  if "$REAL_STAT" -c "$2" "$3" 2>/dev/null; then
+    exit 0
+  fi
+
+  case "$2" in
+    '%a') exec "$REAL_STAT" -f '%Lp' "$3" ;;
+    '%u') exec "$REAL_STAT" -f '%u' "$3" ;;
+    '%Y') exec "$REAL_STAT" -f '%m' "$3" ;;
+  esac
+fi
+
+exec "$REAL_STAT" "$@"
+EOF
+  chmod 755 "$TEST_ROOT/bin/stat"
+  export REAL_STAT="$real_stat"
+}
+
 make_valid_cache() {
   printf '%s\n' \
     '# local cache' \
@@ -62,8 +93,8 @@ make_valid_cache() {
   run env PATH="$TEST_ROOT/bin:$PATH" "$AGENT_SECRETS" refresh
 
   [ "$status" -eq 0 ]
-  [ "$(stat -f '%Lp' "$AGENT_SECRETS_DIR" 2>/dev/null || stat -c '%a' "$AGENT_SECRETS_DIR")" = "700" ]
-  [ "$(stat -f '%Lp' "$AGENT_SECRETS_CACHE" 2>/dev/null || stat -c '%a' "$AGENT_SECRETS_CACHE")" = "600" ]
+  [ "$(stat -c '%a' "$AGENT_SECRETS_DIR" 2>/dev/null || stat -f '%Lp' "$AGENT_SECRETS_DIR")" = "700" ]
+  [ "$(stat -c '%a' "$AGENT_SECRETS_CACHE" 2>/dev/null || stat -f '%Lp' "$AGENT_SECRETS_CACHE")" = "600" ]
   grep -q '^WORK_BRAIN_BEARER_TOKEN=resolved token=with spaces$' "$AGENT_SECRETS_CACHE"
   run find "$AGENT_SECRETS_DIR" -name 'env.cache.tmp.*' -print
   [ "$status" -eq 0 ]
@@ -111,6 +142,18 @@ make_valid_cache() {
 
   [ "$status" -eq 7 ]
   [ "$output" = 'value with spaces|value=with=equals|argument with spaces' ]
+}
+
+@test "GNU stat on macOS does not pollute cache metadata" {
+  make_valid_cache
+  install_gnu_stat_stub
+
+  run env PATH="$TEST_ROOT/bin:$PATH" REAL_STAT="$REAL_STAT" "$AGENT_SECRETS" status
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'Mode: 600'* ]]
+  [[ "$output" == *'Status: valid'* ]]
+  [[ "$output" != *'Block size:'* ]]
 }
 
 @test "exec treats shell syntax in values as data" {


### PR DESCRIPTION
## Summary

- prefer GNU-style `stat -c` before falling back to BSD/macOS `stat -f`
- prevent failed GNU filesystem-stat output from polluting permission and metadata checks
- add regression coverage for GNU coreutils shadowing macOS `stat` inside Nix shells

## Root cause

PR #9 tried BSD `stat -f` first. GNU `stat` interprets `-f` as filesystem mode, emits filesystem metadata before failing on the BSD format argument, and then the fallback appends the correct mode. The combined output fails the strict `700`/`600` comparison even though permissions are correct.

## Testing

- `bats test/agent-secrets.bats`
- Bats suite with Homebrew GNU coreutils first in `PATH`
- `shellcheck bin/agent-secrets test/agent-secrets.bats`
- `DOTFILES_DIR="$PWD" bin/dotfiles test`
- validated the active cache with GNU `stat`: `Status: valid`